### PR TITLE
Replace Win2D with SharpDX

### DIFF
--- a/CaptureEncoder/CaptureEncoder.csproj
+++ b/CaptureEncoder/CaptureEncoder.csproj
@@ -122,6 +122,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CaptureFrameWait.cs" />
+    <Compile Include="Direct3D11Helpers.cs" />
     <Compile Include="Encoder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -129,8 +130,8 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.3</Version>
     </PackageReference>
-    <PackageReference Include="Win2D.uwp">
-      <Version>1.23.0</Version>
+    <PackageReference Include="SharpDX.Direct3D11">
+      <Version>4.2.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/CaptureEncoder/CaptureFrameWait.cs
+++ b/CaptureEncoder/CaptureFrameWait.cs
@@ -105,15 +105,20 @@ namespace CaptureEncoder
             var result = new SurfaceWithInfo();
             if (MakeCopy)
             {
-                var sourceTexture = Direct3D11Helpers.CreateSharpDXTexture2D(_currentFrame.Surface);
-                var description = sourceTexture.Description;
-                description.Usage = SharpDX.Direct3D11.ResourceUsage.Default;
-                description.BindFlags = SharpDX.Direct3D11.BindFlags.ShaderResource;
-                description.CpuAccessFlags = SharpDX.Direct3D11.CpuAccessFlags.None;
-                var copyTexture = new SharpDX.Direct3D11.Texture2D(_d3dDevice, description);
-                _d3dDevice.ImmediateContext.CopyResource(sourceTexture, copyTexture);
+                using (var sourceTexture = Direct3D11Helpers.CreateSharpDXTexture2D(_currentFrame.Surface))
+                {
+                    var description = sourceTexture.Description;
+                    description.Usage = SharpDX.Direct3D11.ResourceUsage.Default;
+                    description.BindFlags = SharpDX.Direct3D11.BindFlags.ShaderResource | SharpDX.Direct3D11.BindFlags.RenderTarget;
+                    description.CpuAccessFlags = SharpDX.Direct3D11.CpuAccessFlags.None;
+                    description.OptionFlags = SharpDX.Direct3D11.ResourceOptionFlags.None;
 
-                result.Surface = Direct3D11Helpers.CreateDirect3DSurfaceFromSharpDXTexture(copyTexture);
+                    using (var copyTexture = new SharpDX.Direct3D11.Texture2D(_d3dDevice, description))
+                    {
+                        _d3dDevice.ImmediateContext.CopyResource(sourceTexture, copyTexture);
+                        result.Surface = Direct3D11Helpers.CreateDirect3DSurfaceFromSharpDXTexture(copyTexture);
+                    }
+                }
             }
             else
             {

--- a/CaptureEncoder/CaptureFrameWait.cs
+++ b/CaptureEncoder/CaptureFrameWait.cs
@@ -32,7 +32,7 @@ namespace CaptureEncoder
             Debug.WriteLine($"MakeCopy: {MakeCopy}");
 
             _device = device;
-            _d3dDevice = Direct3D11Helpers.GetSharpDXDevice(device);
+            _d3dDevice = Direct3D11Helpers.CreateSharpDXDevice(device);
             _item = item;
             _frameEvent = new ManualResetEvent(false);
             _closedEvent = new ManualResetEvent(false);
@@ -105,16 +105,15 @@ namespace CaptureEncoder
             var result = new SurfaceWithInfo();
             if (MakeCopy)
             {
-                var sourceTexture = Direct3D11Helpers.GetSharpDXTexture2D(_currentFrame.Surface);
+                var sourceTexture = Direct3D11Helpers.CreateSharpDXTexture2D(_currentFrame.Surface);
                 var description = sourceTexture.Description;
                 description.Usage = SharpDX.Direct3D11.ResourceUsage.Default;
-                description.BindFlags = 0;
-                description.CpuAccessFlags = 0;
-                description.MipLevels = 0;
+                description.BindFlags = SharpDX.Direct3D11.BindFlags.ShaderResource;
+                description.CpuAccessFlags = SharpDX.Direct3D11.CpuAccessFlags.None;
                 var copyTexture = new SharpDX.Direct3D11.Texture2D(_d3dDevice, description);
                 _d3dDevice.ImmediateContext.CopyResource(sourceTexture, copyTexture);
 
-                result.Surface = new SharpDXWinRTSurface(copyTexture);
+                result.Surface = Direct3D11Helpers.CreateDirect3DSurfaceFromSharpDXTexture(copyTexture);
             }
             else
             {

--- a/CaptureEncoder/CaptureFrameWait.cs
+++ b/CaptureEncoder/CaptureFrameWait.cs
@@ -21,6 +21,23 @@ namespace CaptureEncoder
         }
     }
 
+    class MultithreadLock : IDisposable
+    {
+        public MultithreadLock(SharpDX.Direct3D11.Multithread multithread)
+        {
+            _multithread = multithread;
+            _multithread?.Enter();
+        }
+
+        public void Dispose()
+        {
+            _multithread?.Leave();
+            _multithread = null;
+        }
+
+        private SharpDX.Direct3D11.Multithread _multithread;
+    }
+
     public sealed class CaptureFrameWait : IDisposable
     {
         public CaptureFrameWait(
@@ -28,16 +45,16 @@ namespace CaptureEncoder
             GraphicsCaptureItem item,
             SizeInt32 size)
         {
-            MakeCopy = !ApiInformation.IsApiContractPresent(typeof(Windows.Foundation.UniversalApiContract).FullName, 8);
-            Debug.WriteLine($"MakeCopy: {MakeCopy}");
-
             _device = device;
             _d3dDevice = Direct3D11Helpers.CreateSharpDXDevice(device);
+            _multithread = _d3dDevice.QueryInterface<SharpDX.Direct3D11.Multithread>();
+            _multithread.SetMultithreadProtected(true);
             _item = item;
             _frameEvent = new ManualResetEvent(false);
             _closedEvent = new ManualResetEvent(false);
             _events = new[] { _closedEvent, _frameEvent };
 
+            InitializeBlankTexture(size);
             InitializeCapture(size);
         }
 
@@ -52,6 +69,33 @@ namespace CaptureEncoder
             _framePool.FrameArrived += OnFrameArrived;
             _session = _framePool.CreateCaptureSession(_item);
             _session.StartCapture();
+        }
+
+        private void InitializeBlankTexture(SizeInt32 size)
+        {
+            var description = new SharpDX.Direct3D11.Texture2DDescription
+            {
+                Width = size.Width,
+                Height = size.Height,
+                MipLevels = 1,
+                ArraySize = 1,
+                Format = SharpDX.DXGI.Format.B8G8R8A8_UNorm,
+                SampleDescription = new SharpDX.DXGI.SampleDescription()
+                {
+                    Count = 1,
+                    Quality = 0
+                },
+                Usage = SharpDX.Direct3D11.ResourceUsage.Default,
+                BindFlags = SharpDX.Direct3D11.BindFlags.ShaderResource | SharpDX.Direct3D11.BindFlags.RenderTarget,
+                CpuAccessFlags = SharpDX.Direct3D11.CpuAccessFlags.None,
+                OptionFlags = SharpDX.Direct3D11.ResourceOptionFlags.None
+            };
+            _blankTexture = new SharpDX.Direct3D11.Texture2D(_d3dDevice, description);
+
+            using (var renderTargetView = new SharpDX.Direct3D11.RenderTargetView(_d3dDevice, _blankTexture))
+            {
+                _d3dDevice.ImmediateContext.ClearRenderTargetView(renderTargetView, new SharpDX.Mathematics.Interop.RawColor4(0, 0, 0, 1));
+            }
         }
 
         private void SetResult(Direct3D11CaptureFrame frame)
@@ -86,6 +130,8 @@ namespace CaptureEncoder
             _item = null;
             _device = null;
             _d3dDevice = null;
+            _blankTexture?.Dispose();
+            _blankTexture = null;
             _currentFrame?.Dispose();
         }
 
@@ -103,29 +149,28 @@ namespace CaptureEncoder
             }
 
             var result = new SurfaceWithInfo();
-            if (MakeCopy)
+            result.SystemRelativeTime = _currentFrame.SystemRelativeTime;
+            using (var multithreadLock = new MultithreadLock(_multithread))
+            using (var sourceTexture = Direct3D11Helpers.CreateSharpDXTexture2D(_currentFrame.Surface))
             {
-                using (var sourceTexture = Direct3D11Helpers.CreateSharpDXTexture2D(_currentFrame.Surface))
-                {
-                    var description = sourceTexture.Description;
-                    description.Usage = SharpDX.Direct3D11.ResourceUsage.Default;
-                    description.BindFlags = SharpDX.Direct3D11.BindFlags.ShaderResource | SharpDX.Direct3D11.BindFlags.RenderTarget;
-                    description.CpuAccessFlags = SharpDX.Direct3D11.CpuAccessFlags.None;
-                    description.OptionFlags = SharpDX.Direct3D11.ResourceOptionFlags.None;
+                var description = sourceTexture.Description;
+                description.Usage = SharpDX.Direct3D11.ResourceUsage.Default;
+                description.BindFlags = SharpDX.Direct3D11.BindFlags.ShaderResource | SharpDX.Direct3D11.BindFlags.RenderTarget;
+                description.CpuAccessFlags = SharpDX.Direct3D11.CpuAccessFlags.None;
+                description.OptionFlags = SharpDX.Direct3D11.ResourceOptionFlags.None;
 
-                    using (var copyTexture = new SharpDX.Direct3D11.Texture2D(_d3dDevice, description))
-                    {
-                        _d3dDevice.ImmediateContext.CopyResource(sourceTexture, copyTexture);
-                        result.Surface = Direct3D11Helpers.CreateDirect3DSurfaceFromSharpDXTexture(copyTexture);
-                    }
+                using (var copyTexture = new SharpDX.Direct3D11.Texture2D(_d3dDevice, description))
+                {
+                    var width = Math.Clamp(_currentFrame.ContentSize.Width, 0, _currentFrame.Surface.Description.Width);
+                    var height = Math.Clamp(_currentFrame.ContentSize.Height, 0, _currentFrame.Surface.Description.Height);
+
+                    var region = new SharpDX.Direct3D11.ResourceRegion(0, 0, 0, width, height, 1);
+
+                    _d3dDevice.ImmediateContext.CopyResource(_blankTexture, copyTexture);
+                    _d3dDevice.ImmediateContext.CopySubresourceRegion(sourceTexture, 0, region, copyTexture, 0);
+                    result.Surface = Direct3D11Helpers.CreateDirect3DSurfaceFromSharpDXTexture(copyTexture);
                 }
             }
-            else
-            {
-                result.Surface = _currentFrame.Surface;
-            }
-
-            result.SystemRelativeTime = _currentFrame.SystemRelativeTime;
 
             return result;
         }
@@ -138,6 +183,8 @@ namespace CaptureEncoder
 
         private IDirect3DDevice _device;
         private SharpDX.Direct3D11.Device _d3dDevice;
+        private SharpDX.Direct3D11.Multithread _multithread;
+        private SharpDX.Direct3D11.Texture2D _blankTexture;
 
         private ManualResetEvent[] _events;
         private ManualResetEvent _frameEvent;
@@ -147,7 +194,5 @@ namespace CaptureEncoder
         private GraphicsCaptureItem _item;
         private GraphicsCaptureSession _session;
         private Direct3D11CaptureFramePool _framePool;
-
-        private readonly bool MakeCopy;
     }
 }

--- a/CaptureEncoder/Direct3D11Helpers.cs
+++ b/CaptureEncoder/Direct3D11Helpers.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Windows.Graphics.DirectX;
+using Windows.Graphics.DirectX.Direct3D11;
+
+namespace CaptureEncoder
+{
+    [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("A9B3D012-3DF2-4EE3-B8D1-8695F457D3C1")]
+    interface IDirect3DDxgiInterfaceAccess
+    {
+        uint GetInterface(Guid iid, out IntPtr p);
+    }
+
+    public static class Direct3D11Helpers
+    {
+        public static IDirect3DDevice CreateDevice()
+        {
+            return CreateDevice(false);
+        }
+
+        public static IDirect3DDevice CreateDevice(bool useWARP)
+        {
+            var d3dDevice = new SharpDX.Direct3D11.Device(
+                useWARP ? SharpDX.Direct3D.DriverType.Software : SharpDX.Direct3D.DriverType.Hardware,
+                SharpDX.Direct3D11.DeviceCreationFlags.BgraSupport);
+            return new SharpDXWinRTDevice(d3dDevice.QueryInterface<SharpDX.Direct3D11.Device5>());
+        }
+
+        internal static SharpDX.Direct3D11.Device GetSharpDXDevice(IDirect3DDevice device)
+        {
+            var access = (IDirect3DDxgiInterfaceAccess)device;
+            // guid taken from d3d11.h
+            var d3dPointer = new IntPtr();
+            var result = access.GetInterface(new Guid("db6f6ddb-ac77-4e88-8253-819df9bbf140"), out d3dPointer);
+            if (result != 0)
+            {
+                throw new Exception($"0x{result:X8}");
+            }
+            var d3dDevice = new SharpDX.Direct3D11.Device(d3dPointer);
+            return d3dDevice;
+        }
+
+        internal static SharpDX.Direct3D11.Texture2D GetSharpDXTexture2D(IDirect3DSurface surface)
+        {
+            var access = (IDirect3DDxgiInterfaceAccess)surface;
+            // guid taken from d3d11.h
+            var d3dPointer = new IntPtr();
+            var result = access.GetInterface(new Guid("6f15aaf2-d208-4e89-9ab4-489535d34f9c"), out d3dPointer);
+            if (result != 0)
+            {
+                throw new Exception($"0x{result:X8}");
+            }
+            var d3dSurface = new SharpDX.Direct3D11.Texture2D(d3dPointer);
+            return d3dSurface;
+        }
+    }
+
+    class SharpDXWinRTWrapper<T> : IDirect3DDxgiInterfaceAccess where T : SharpDX.ComObject
+    {
+        public SharpDXWinRTWrapper(T resource)
+        {
+            _resource = resource;
+        }
+
+        public void Dispose()
+        {
+            _resource?.Dispose();
+            _resource = null;
+        }
+
+        public uint GetInterface(Guid iid, out IntPtr p)
+        {
+            CheckClosed();
+
+            try
+            {
+                _resource.QueryInterface(iid, out p);
+            }
+            catch (Exception ex)
+            {
+                p = new IntPtr();
+                return (uint)ex.HResult;
+            }
+            
+            return 0;
+        }
+
+        protected void CheckClosed()
+        {
+            if (_resource == null)
+            {
+                throw new ObjectDisposedException(nameof(SharpDXWinRTDevice));
+            }
+        }
+
+        protected T _resource;
+    }
+
+
+    class SharpDXWinRTDevice : SharpDXWinRTWrapper<SharpDX.Direct3D11.Device5>, IDirect3DDevice
+    {
+        public SharpDXWinRTDevice(SharpDX.Direct3D11.Device5 device) : base(device)
+        {
+        }
+
+        public void Trim()
+        {
+            CheckClosed();
+
+            var dxgiDevice = _resource.QueryInterface<SharpDX.DXGI.Device3>();
+            dxgiDevice.Trim();
+        }
+    }
+
+    class SharpDXWinRTSurface : SharpDXWinRTWrapper<SharpDX.Direct3D11.Texture2D>, IDirect3DSurface
+    {
+        public SharpDXWinRTSurface(SharpDX.Direct3D11.Texture2D surface) : base(surface)
+        {
+            var sharpDXDescription = _resource.Description;
+            Description = new Direct3DSurfaceDescription()
+            {
+                Width = sharpDXDescription.Width,
+                Height = sharpDXDescription.Height,
+                Format = (DirectXPixelFormat)sharpDXDescription.Format,
+                MultisampleDescription = new Direct3DMultisampleDescription()
+                {
+                    Count = sharpDXDescription.SampleDescription.Count,
+                    Quality = sharpDXDescription.SampleDescription.Quality
+                }
+            };
+        }
+
+        public Direct3DSurfaceDescription Description { get; }
+    }
+}

--- a/CaptureEncoder/Direct3D11Helpers.cs
+++ b/CaptureEncoder/Direct3D11Helpers.cs
@@ -5,14 +5,43 @@ using Windows.Graphics.DirectX.Direct3D11;
 
 namespace CaptureEncoder
 {
-    [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("A9B3D012-3DF2-4EE3-B8D1-8695F457D3C1")]
+    [ComImport]
+    [Guid("A9B3D012-3DF2-4EE3-B8D1-8695F457D3C1")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [ComVisible(true)]
     interface IDirect3DDxgiInterfaceAccess
     {
-        uint GetInterface(Guid iid, out IntPtr p);
-    }
+        IntPtr GetInterface([In] ref Guid iid);
+    };
 
     public static class Direct3D11Helpers
     {
+        internal static Guid IInspectable = new Guid("AF86E2E0-B12D-4c6a-9C5A-D7AA65101E90");
+        internal static Guid ID3D11Resource = new Guid("dc8e63f3-d12b-4952-b47b-5e45026a862d");
+        internal static Guid IDXGIAdapter3 = new Guid("645967A4-1392-4310-A798-8053CE3E93FD");
+        internal static Guid ID3D11Device = new Guid("db6f6ddb-ac77-4e88-8253-819df9bbf140");
+        internal static Guid ID3D11Texture2D = new Guid("6f15aaf2-d208-4e89-9ab4-489535d34f9c");
+
+        [DllImport(
+            "d3d11.dll",
+            EntryPoint = "CreateDirect3D11DeviceFromDXGIDevice",
+            SetLastError = true,
+            CharSet = CharSet.Unicode,
+            ExactSpelling = true,
+            CallingConvention = CallingConvention.StdCall
+            )]
+        internal static extern UInt32 CreateDirect3D11DeviceFromDXGIDevice(IntPtr dxgiDevice, out IntPtr graphicsDevice);
+
+        [DllImport(
+            "d3d11.dll",
+            EntryPoint = "CreateDirect3D11SurfaceFromDXGISurface",
+            SetLastError = true,
+            CharSet = CharSet.Unicode,
+            ExactSpelling = true,
+            CallingConvention = CallingConvention.StdCall
+            )]
+        internal static extern UInt32 CreateDirect3D11SurfaceFromDXGISurface(IntPtr dxgiSurface, out IntPtr graphicsSurface);
+
         public static IDirect3DDevice CreateDevice()
         {
             return CreateDevice(false);
@@ -23,113 +52,58 @@ namespace CaptureEncoder
             var d3dDevice = new SharpDX.Direct3D11.Device(
                 useWARP ? SharpDX.Direct3D.DriverType.Software : SharpDX.Direct3D.DriverType.Hardware,
                 SharpDX.Direct3D11.DeviceCreationFlags.BgraSupport);
-            return new SharpDXWinRTDevice(d3dDevice.QueryInterface<SharpDX.Direct3D11.Device5>());
+            IDirect3DDevice device = null;
+
+            // Acquire the DXGI interface for the Direct3D device.
+            using (var dxgiDevice = d3dDevice.QueryInterface<SharpDX.DXGI.Device3>())
+            {
+                // Wrap the native device using a WinRT interop object.
+                uint hr = CreateDirect3D11DeviceFromDXGIDevice(dxgiDevice.NativePointer, out IntPtr pUnknown);
+
+                if (hr == 0)
+                {
+                    device = Marshal.GetObjectForIUnknown(pUnknown) as IDirect3DDevice;
+                    Marshal.Release(pUnknown);
+                }
+            }
+
+            return device;
         }
 
-        internal static SharpDX.Direct3D11.Device GetSharpDXDevice(IDirect3DDevice device)
+        internal static IDirect3DSurface CreateDirect3DSurfaceFromSharpDXTexture(SharpDX.Direct3D11.Texture2D texture)
+        {
+            IDirect3DSurface surface = null;
+
+            // Acquire the DXGI interface for the Direct3D surface.
+            using (var dxgiSurface = texture.QueryInterface<SharpDX.DXGI.Surface>())
+            {
+                // Wrap the native device using a WinRT interop object.
+                uint hr = CreateDirect3D11SurfaceFromDXGISurface(dxgiSurface.NativePointer, out IntPtr pUnknown);
+
+                if (hr == 0)
+                {
+                    surface = Marshal.GetObjectForIUnknown(pUnknown) as IDirect3DSurface;
+                    Marshal.Release(pUnknown);
+                }
+            }
+
+            return surface;
+        }
+
+        internal static SharpDX.Direct3D11.Device CreateSharpDXDevice(IDirect3DDevice device)
         {
             var access = (IDirect3DDxgiInterfaceAccess)device;
-            // guid taken from d3d11.h
-            var d3dPointer = new IntPtr();
-            var result = access.GetInterface(new Guid("db6f6ddb-ac77-4e88-8253-819df9bbf140"), out d3dPointer);
-            if (result != 0)
-            {
-                throw new Exception($"0x{result:X8}");
-            }
+            var d3dPointer = access.GetInterface(ID3D11Device);
             var d3dDevice = new SharpDX.Direct3D11.Device(d3dPointer);
             return d3dDevice;
         }
 
-        internal static SharpDX.Direct3D11.Texture2D GetSharpDXTexture2D(IDirect3DSurface surface)
+        internal static SharpDX.Direct3D11.Texture2D CreateSharpDXTexture2D(IDirect3DSurface surface)
         {
             var access = (IDirect3DDxgiInterfaceAccess)surface;
-            // guid taken from d3d11.h
-            var d3dPointer = new IntPtr();
-            var result = access.GetInterface(new Guid("6f15aaf2-d208-4e89-9ab4-489535d34f9c"), out d3dPointer);
-            if (result != 0)
-            {
-                throw new Exception($"0x{result:X8}");
-            }
+            var d3dPointer = access.GetInterface(ID3D11Texture2D);
             var d3dSurface = new SharpDX.Direct3D11.Texture2D(d3dPointer);
             return d3dSurface;
         }
-    }
-
-    class SharpDXWinRTWrapper<T> : IDirect3DDxgiInterfaceAccess where T : SharpDX.ComObject
-    {
-        public SharpDXWinRTWrapper(T resource)
-        {
-            _resource = resource;
-        }
-
-        public void Dispose()
-        {
-            _resource?.Dispose();
-            _resource = null;
-        }
-
-        public uint GetInterface(Guid iid, out IntPtr p)
-        {
-            CheckClosed();
-
-            try
-            {
-                _resource.QueryInterface(iid, out p);
-            }
-            catch (Exception ex)
-            {
-                p = new IntPtr();
-                return (uint)ex.HResult;
-            }
-            
-            return 0;
-        }
-
-        protected void CheckClosed()
-        {
-            if (_resource == null)
-            {
-                throw new ObjectDisposedException(nameof(SharpDXWinRTDevice));
-            }
-        }
-
-        protected T _resource;
-    }
-
-
-    class SharpDXWinRTDevice : SharpDXWinRTWrapper<SharpDX.Direct3D11.Device5>, IDirect3DDevice
-    {
-        public SharpDXWinRTDevice(SharpDX.Direct3D11.Device5 device) : base(device)
-        {
-        }
-
-        public void Trim()
-        {
-            CheckClosed();
-
-            var dxgiDevice = _resource.QueryInterface<SharpDX.DXGI.Device3>();
-            dxgiDevice.Trim();
-        }
-    }
-
-    class SharpDXWinRTSurface : SharpDXWinRTWrapper<SharpDX.Direct3D11.Texture2D>, IDirect3DSurface
-    {
-        public SharpDXWinRTSurface(SharpDX.Direct3D11.Texture2D surface) : base(surface)
-        {
-            var sharpDXDescription = _resource.Description;
-            Description = new Direct3DSurfaceDescription()
-            {
-                Width = sharpDXDescription.Width,
-                Height = sharpDXDescription.Height,
-                Format = (DirectXPixelFormat)sharpDXDescription.Format,
-                MultisampleDescription = new Direct3DMultisampleDescription()
-                {
-                    Count = sharpDXDescription.SampleDescription.Count,
-                    Quality = sharpDXDescription.SampleDescription.Quality
-                }
-            };
-        }
-
-        public Direct3DSurfaceDescription Description { get; }
     }
 }

--- a/SimpleRecorder/MainPage.xaml.cs
+++ b/SimpleRecorder/MainPage.xaml.cs
@@ -1,10 +1,10 @@
 ﻿using CaptureEncoder;
-using Microsoft.Graphics.Canvas;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Windows.Graphics.Capture;
+using Windows.Graphics.DirectX.Direct3D11;
 using Windows.Media.MediaProperties;
 using Windows.Storage;
 using Windows.Storage.Pickers;
@@ -36,7 +36,7 @@ namespace SimpleRecorder
                 return;
             }
 
-            _device = new CanvasDevice();
+            _device = Direct3D11Helpers.CreateDevice();
 
             var settings = GetCachedSettings();
 
@@ -256,7 +256,7 @@ namespace SimpleRecorder
             public bool UseSourceSize;
         }
 
-        private CanvasDevice _device;
+        private IDirect3DDevice _device;
         private Encoder _encoder;
     }
 }

--- a/SimpleRecorder/SimpleRecorder.csproj
+++ b/SimpleRecorder/SimpleRecorder.csproj
@@ -161,9 +161,6 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.3</Version>
     </PackageReference>
-    <PackageReference Include="Win2D.uwp">
-      <Version>1.23.0</Version>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CaptureEncoder\CaptureEncoder.csproj">


### PR DESCRIPTION
This change replaces Win2D with SharpDX. Doing this allows for proper synchronization. It also addresses issues #3 and #6 .