### PR TITLE
Decrease minimum size for recording window

### DIFF
--- a/SimpleRecorder/MainPage.xaml.cs
+++ b/SimpleRecorder/MainPage.xaml.cs
@@ -15,6 +15,8 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Media;
+using Windows.Foundation;
+using Windows.UI.ViewManagement;
 
 namespace SimpleRecorder
 {
@@ -23,6 +25,9 @@ namespace SimpleRecorder
         public MainPage()
         {
             InitializeComponent();
+            
+            ApplicationView.GetForCurrentView().SetPreferredMinSize(
+               new Size(350, 200));
 
             if (!GraphicsCaptureSession.IsSupported())
             {


### PR DESCRIPTION
With the current UI, I prefer to keep the recording window resized, with this pull request I have reduced a bit more the minimum size for the window. Here's a preview of how it looks like
![image](https://user-images.githubusercontent.com/43090263/85784460-96838d00-b728-11ea-8ca6-fb3946a72dbc.png)
